### PR TITLE
Makes Event Audit work

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,0 +1,8 @@
+fixtures:
+    symlinks:
+      local_security_policy: "#{source_dir}"
+    repositories:
+      stdlib:
+        repo: https://github.com/puppetlabs/puppetlabs-stdlib.git
+        ref: 4.3.2
+    forge_modules:

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.*.sw?
+pkg
+spec/fixtures
+.rspec_system
+.vagrant
+.bundle
+vendor
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+branches:
+script: "bundle exec rake spec SPEC_OPTS='--format documentation'"
+bundler_args: --without development
+
+rvm:
+- 1.9.3
+- 2.0.0
+- 2.1.5
+- 2.2.0
+env:
+  matrix:
+    - PUPPET_GEM_VERSION="~> 3.2"
+    - PUPPET_GEM_VERSION="~> 3.7"
+

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,21 @@
+source "https://rubygems.org"
+
+group :test do
+gem "rake"
+gem "puppet", ENV['PUPPET_VERSION'] || '~> 3.7.3'
+gem "rspec-puppet", :git => 'https://github.com/rodjek/rspec-puppet.git'
+gem "puppetlabs_spec_helper"
+gem 'rspec-puppet-utils', :git => 'https://github.com/Accuity/rspec-puppet-utils.git'
+# there seems to be a bug with puppet-blacksmith and metadata-json-lint
+# removing metadata for now
+gem "metadata-json-lint"
+gem 'puppet-syntax'
+gem 'puppet-lint'
+end
+
+group :development do
+gem "travis"
+gem "travis-lint"
+gem "puppet-blacksmith"
+end
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,140 @@
+GIT
+  remote: https://github.com/Accuity/rspec-puppet-utils.git
+  revision: 11925d8684b6c75d691ede7cb59fa007681b1621
+  specs:
+    rspec-puppet-utils (2.0.6)
+
+GIT
+  remote: https://github.com/rodjek/rspec-puppet.git
+  revision: f69b47ec113d6d27df44f41ef74cdde435af3530
+  specs:
+    rspec-puppet (2.2.1.pre)
+      rspec
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    CFPropertyList (2.2.8)
+    addressable (2.3.8)
+    backports (3.6.4)
+    coderay (1.1.0)
+    diff-lcs (1.2.5)
+    domain_name (0.5.24)
+      unf (>= 0.0.5, < 1.0.0)
+    ethon (0.7.4)
+      ffi (>= 1.3.0)
+    facter (2.4.4)
+      CFPropertyList (~> 2.2.6)
+    faraday (0.9.1)
+      multipart-post (>= 1.2, < 3)
+    faraday_middleware (0.9.1)
+      faraday (>= 0.7.4, < 0.10)
+    ffi (1.9.9)
+    gh (0.14.0)
+      addressable
+      backports
+      faraday (~> 0.8)
+      multi_json (~> 1.0)
+      net-http-persistent (>= 2.7)
+      net-http-pipeline
+    hiera (1.3.4)
+      json_pure
+    highline (1.7.2)
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
+    json (1.8.3)
+    json_pure (1.8.2)
+    launchy (2.4.3)
+      addressable (~> 2.3)
+    metaclass (0.0.4)
+    metadata-json-lint (0.0.6)
+      json
+      spdx-licenses (~> 1.0)
+    method_source (0.8.2)
+    mime-types (2.6.1)
+    mocha (1.1.0)
+      metaclass (~> 0.0.1)
+    multi_json (1.11.1)
+    multipart-post (2.0.0)
+    net-http-persistent (2.9.4)
+    net-http-pipeline (1.0.1)
+    netrc (0.10.3)
+    pry (0.9.12.6)
+      coderay (~> 1.0)
+      method_source (~> 0.8)
+      slop (~> 3.4)
+    puppet (3.7.5)
+      facter (> 1.6, < 3)
+      hiera (~> 1.0)
+      json_pure
+    puppet-blacksmith (3.3.1)
+      puppet (>= 2.7.16)
+      rest-client
+    puppet-lint (1.1.0)
+    puppet-syntax (2.0.0)
+      rake
+    puppetlabs_spec_helper (0.10.3)
+      mocha
+      puppet-lint
+      puppet-syntax
+      rake
+      rspec-puppet
+    pusher-client (0.6.2)
+      json
+      websocket (~> 1.0)
+    rake (10.4.2)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
+    rspec (3.3.0)
+      rspec-core (~> 3.3.0)
+      rspec-expectations (~> 3.3.0)
+      rspec-mocks (~> 3.3.0)
+    rspec-core (3.3.1)
+      rspec-support (~> 3.3.0)
+    rspec-expectations (3.3.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.3.0)
+    rspec-mocks (3.3.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.3.0)
+    rspec-support (3.3.0)
+    slop (3.6.0)
+    spdx-licenses (1.0.0)
+      json
+    travis (1.7.7)
+      addressable (~> 2.3)
+      backports
+      faraday (~> 0.9)
+      faraday_middleware (~> 0.9, >= 0.9.1)
+      gh (~> 0.13)
+      highline (~> 1.6)
+      launchy (~> 2.1)
+      pry (~> 0.9, < 0.10)
+      pusher-client (~> 0.4)
+      typhoeus (~> 0.6, >= 0.6.8)
+    travis-lint (2.0.0)
+      json
+    typhoeus (0.7.2)
+      ethon (>= 0.7.4)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.1)
+    websocket (1.2.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  metadata-json-lint
+  puppet (~> 3.7.3)
+  puppet-blacksmith
+  puppet-lint
+  puppet-syntax
+  puppetlabs_spec_helper
+  rake
+  rspec-puppet!
+  rspec-puppet-utils!
+  travis
+  travis-lint

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,44 @@
+require 'puppetlabs_spec_helper/rake_tasks'
+require 'puppet-lint/tasks/puppet-lint'
+require 'puppet-syntax/tasks/puppet-syntax'
+
+# These two gems aren't always present, for instance
+# on Travis with --without development
+begin
+  require 'puppet_blacksmith/rake_tasks'
+  Blacksmith::RakeTask.new do |t|
+    t.tag_pattern = "v%s" # Use a custom pattern with git tag. %s is replaced with the version number.
+  end
+rescue LoadError
+end
+
+PuppetLint.configuration.relative = true
+PuppetLint.configuration.send("disable_80chars")
+PuppetLint.configuration.log_format = "%{path}:%{linenumber}:%{check}:%{KIND}:%{message}"
+PuppetLint.configuration.fail_on_warnings = true
+
+# Forsake support for Puppet 2.6.2 for the benefit of cleaner code.
+# http://puppet-lint.com/checks/class_parameter_defaults/
+PuppetLint.configuration.send('disable_class_parameter_defaults')
+# http://puppet-lint.com/checks/class_inherits_from_params_class/
+PuppetLint.configuration.send('disable_class_inherits_from_params_class')
+
+exclude_paths = [
+  "pkg/**/*",
+  "vendor/**/*",
+  "spec/**/*",
+]
+PuppetLint.configuration.ignore_paths = exclude_paths
+PuppetSyntax.exclude_paths = exclude_paths
+
+task :metadata do
+  sh "metadata-json-lint metadata.json"
+end
+
+desc "Run syntax, lint, and spec tests."
+task :test => [
+       :syntax,
+       :lint,
+       :spec,
+       :metadata,
+     ]

--- a/lib/puppet/provider/local_security_policy/policy.rb
+++ b/lib/puppet/provider/local_security_policy/policy.rb
@@ -643,7 +643,7 @@ Puppet::Type.type(:local_security_policy).provide(:policy) do
   def flush
     if @property_flush
       time = Time.now
-      time = time.strftime("%Y%m%d%H%M%S")
+      time = time.strftime("%Y%m%d%H%M%S%L")
       infout = "c:\\windows\\temp\\infimport-#{time}.inf"
       sdbout = "c:\\windows\\temp\\sdbimport-#{time}.inf"
       if not @property_hash[:policy_setting].nil?

--- a/lib/puppet/provider/local_security_policy/policy.rb
+++ b/lib/puppet/provider/local_security_policy/policy.rb
@@ -493,11 +493,11 @@ Puppet::Type.type(:local_security_policy).provide(:policy) do
             policy_value = users.sort.join(",")
           elsif section_header == 'Event Audit'
             case policy_value.to_s
-            when 3
+            when '3'
               policy_value = "Success,Failure"
-            when 2
+            when '2'
               policy_value = "Failure"
-            when 1
+            when '1'
               policy_value = "Success"
             else
               policy_value = "No auditing"
@@ -673,10 +673,10 @@ Puppet::Type.type(:local_security_policy).provide(:policy) do
           pv = 0
         else
           pv = 0
-          resource[:policy_value].split(",").split do |ssetting|
-            if setting.strip! == 'Success'
+          resource[:policy_value].split(",").each do |ssetting|
+            if ssetting == 'Success'
               pv += 1
-            elsif setting.strip! == 'Failure'
+            elsif ssetting == 'Failure'
               pv += 2
             end
           end

--- a/spec/classes/local_security_policy_spec.rb
+++ b/spec/classes/local_security_policy_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+require 'shared_contexts'
+
+describe 'local_security_policy' do
+  # by default the hiera integration uses hiera data from the shared_contexts.rb file
+  # but basically to mock hiera you first need to add a key/value pair
+  # to the specific context in the spec/shared_contexts.rb file
+  # Note: you can only use a single hiera context per describe/context block
+  # rspec-puppet does not allow you to swap out hiera data on a per test block
+  #include_context :hiera
+
+
+  # below is the facts hash that gives you the ability to mock
+  # facts on a per describe/context block.  If you use a fact in your
+  # manifest you should mock the facts below.
+  let(:facts) do
+    {}
+  end
+  # below is a list of the resource parameters that you can override.
+  # By default all non-required parameters are commented out,
+  # while all required parameters will require you to add a value
+  let(:params) do
+    {
+    }
+  end
+  # add these two lines in a single test block to enable puppet and hiera debug mode
+  # Puppet::Util::Log.level = :debug
+  # Puppet::Util::Log.newdestination(:console)
+end

--- a/spec/shared_contexts.rb
+++ b/spec/shared_contexts.rb
@@ -1,0 +1,35 @@
+# optional, this should be the path to where the hiera data config file is in this repo
+# You must update this if your actual hiera data lives inside your module.
+# I only assume its data, but it could be anything
+hiera_config_file = File.expand_path(File.join(File.dirname(__FILE__), '..','data', 'hiera.yaml'))
+
+# hiera_config and hiera_data are mutually exclusive contexts.
+
+shared_context :hiera do
+    # example only,
+    let(:hiera_data) do
+        {:some_key => "some_value" }
+    end
+end
+
+shared_context :linux_hiera do
+    # example only,
+    let(:hiera_data) do
+        {:some_key => "some_value" }
+    end
+end
+
+# In case you want a more specific set of mocked hiera data for windows
+shared_context :windows_hiera do
+    # example only,
+    let(:hiera_data) do
+        {:some_key => "some_value" }
+    end
+end
+
+# you cannot use this in addition to any of the hiera_data contexts above
+shared_context :real_hiera_data do
+    let(:hiera_config) do
+       hirea_config_file
+    end
+end

--- a/spec/spec.opts
+++ b/spec/spec.opts
@@ -1,6 +1,0 @@
---format
-s
---colour
---loadby
-mtime
---backtrace

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,10 @@
-require 'rubygems'
 require 'puppetlabs_spec_helper/module_spec_helper'
+require 'rspec-puppet-utils'
+
+# Uncomment this to show coverage report, also useful for debugging
+#at_exit { RSpec::Puppet::Coverage.report! }
+
+RSpec.configure do |c|
+    c.formatter = 'documentation'
+    c.mock_with :rspec
+end

--- a/spec/unit/puppet/provider/local_security_policy/policy_spec.rb
+++ b/spec/unit/puppet/provider/local_security_policy/policy_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+provider_class = Puppet::Type.type(:local_security_policy).provider(:policy)
+
+describe provider_class do
+  subject { provider_class }
+
+  let(:facts)do {:is_virtual => 'false', :osfamily => 'Windows'} end
+
+  let(:resource) {
+    Puppet::Type.type(:local_security_policy).new(
+        :name => 'Network access: Let Everyone permissions apply to anonymous users',
+        :ensure => 'present',
+        :policy_setting => 'MACHINE\System\CurrentControlSet\Control\Lsa\EveryoneIncludesAnonymous',
+        :policy_type    => 'Registry Values',
+        :policy_value   => '0')
+  }
+  let(:provider) {
+    provider_class.new(resource)
+  }
+
+  it 'should create instances without error' do
+    expect(provider_class.instances.class).to eq(Array)
+  end
+
+  it "should be an instance of Puppet::Type::Local_security_policy::ProviderPolicy" do
+    expect(provider).to be_an_instance_of Puppet::Type::Local_security_policy::ProviderPolicy
+  end
+
+end

--- a/spec/unit/puppet/type/local_security_policy/local_security_policy_spec.rb
+++ b/spec/unit/puppet/type/local_security_policy/local_security_policy_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:local_security_policy) do
+  [:name].each do |param|
+    it "should have a #{param} parameter" do
+      expect(Puppet::Type.type(:local_security_policy).attrtype(param)).to eq(:param)
+    end
+  end
+
+  [:policy_type,:ensure, :ensure, :policy_setting, :policy_value].each do |param|
+    it "should have an #{param} property" do
+      expect(Puppet::Type.type(:local_security_policy).attrtype(param)).to eq(:property)
+    end
+  end
+
+end


### PR DESCRIPTION
Small fixes to make Event Audit policies work properly.

* The split() method was being called on an Array.
* Typo in a variable name.
* Avoid overwriting of the .inf files. I had a hard time doing debug because of it.