### PR TITLE
Fix problem loading puppet_x libraries

### DIFF
--- a/lib/puppet/provider/local_security_policy/policy.rb
+++ b/lib/puppet/provider/local_security_policy/policy.rb
@@ -5,9 +5,9 @@ begin
   require "puppet_x/lsp/security_policy"
 rescue LoadError => detail
   require 'pathname' # JJM WORK_AROUND #14073
-  module_base = Pathname.new(__FILE__).dirname
-  require module_base + "../../../" + "puppet_x/twp/inifile.rb"
-  require module_base + "../../../" + "puppet_x/lsp/security_policy.rb"
+  mod = Puppet::Module.find('local_security_policy', Puppet[:environment].to_s)
+  require File.join(mod.path, 'lib/puppet_x/twp/inifile')
+  require File.join(mod.path, 'lib/puppet_x/lsp/security_policy')
 end
 
 Puppet::Type.type(:local_security_policy).provide(:policy) do

--- a/lib/puppet/type/local_security_policy.rb
+++ b/lib/puppet/type/local_security_policy.rb
@@ -2,8 +2,8 @@ begin
   require "puppet_x/lsp/security_policy"
 rescue LoadError => detail
   require 'pathname' # JJM WORK_AROUND #14073
-  module_base = Pathname.new(__FILE__).dirname
-  require module_base + "../../../" + "puppet_x/lsp/security_policy.rb"
+  mod = Puppet::Module.find('local_security_policy', Puppet[:environment].to_s)
+  require File.join(mod.path, 'lib/puppet_x/lsp/security_policy')
 end
 
 Puppet::Type.newtype(:local_security_policy) do


### PR DESCRIPTION
A workaround existed previously but the original implementation did not work on a Windows 7 test system. This commit modifies the workaround to be the same used by Nan Liu in his Archive module. This version works on the systems tested.