### PR TITLE
Changed 'Create a token object' to the correct name

### DIFF
--- a/lib/puppet_x/lsp/security_policy.rb
+++ b/lib/puppet_x/lsp/security_policy.rb
@@ -423,7 +423,7 @@ class SecurityPolicy
                 :policy_type => 'Privilege Rights',
             },
             'Create a token object' => {
-                :name => 'SeAssignPrimaryTokenPrivilege',
+                :name => 'SeCreateTokenPrivilege',
                 :policy_type => 'Privilege Rights',
             },
             'Create global objects' => {


### PR DESCRIPTION
The policy 'Create a token object' had the incorrect name identified, and did not make the proper change on 2012-R2. It now behaves as expected. 