### PR TITLE
New additions and fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ LSP is key to a baseline configuration of the following security features:
 ### Account Policy
   * Password Policy
   * Account Lockout Policy
-  qqqqq
 ### Local Policy
   * Audit Policy
   * User Rights Assignment
@@ -192,6 +191,8 @@ local_security_policy { 'System cryptography: Use FIPS compiant algorithms for e
       Network access: Restrict anonymous access to Named Pipes and Shares
       Network access: Shares that can be accessed anonymously
       Network security: All Local System to use computer identiry for NTLM
+      Network security: Do not store LAN Manager hash value on next password change
+      Network security: LAN Manager authentication level
       Password must meet complexity requirements
       Perform volume maintenance tasks
       Profile single process

--- a/lib/puppet_x/lsp/security_policy.rb
+++ b/lib/puppet_x/lsp/security_policy.rb
@@ -743,7 +743,7 @@ class SecurityPolicy
               :name => 'MACHINE\System\CurrentControlSet\Control\Print\Providers\LanMan Print Services\Servers\AddPrinterDrivers',
               :reg_type => '4',
               :policy_type => 'Registry Values',
-            },              
+            },
             'Devices: Allow undock without having to log on' => {
                 :name => 'MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System\UndockWithoutLogon',
                 :reg_type => '4',
@@ -820,22 +820,22 @@ class SecurityPolicy
                 :policy_type => 'Registry Values',
             },
             'Microsoft network server: Amount of idle time required before suspending session' => {
-                :name => 'MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters\autodisconnect',
+                :name => 'MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters\AutoDisconnect',
                 :reg_type => '4',
                 :policy_type => 'Registry Values',
             },
             'Microsoft network server: Digitally sign communications (always)' => {
-                :name => 'MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters\requiresecuritysignature',
+                :name => 'MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters\RequireSecuritySignature',
                 :reg_type => '4',
                 :policy_type => 'Registry Values',
             },
             'Microsoft network server: Digitally sign communications (if client agrees)' => {
-                :name => 'MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters\enablesecuritysignature',
+                :name => 'MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters\EnableSecuritySignature',
                 :reg_type => '4',
                 :policy_type => 'Registry Values',
             },
             'Microsoft network server: Disconnect clients when logon hours expire' => {
-                :name => 'MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters\enableforcedlogoff',
+                :name => 'MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters\EnableForcedLogOff',
                 :reg_type => '4',
                 :policy_type => 'Registry Values',
             },
@@ -845,7 +845,7 @@ class SecurityPolicy
                 :policy_type => 'Registry Values',
             },
             'Network access: Shares that can be accessed anonymously' => {
-                :name => 'MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters\NullSessionPipes',
+                :name => 'MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters\NullSessionShares',
                 :reg_type => '7',
                 :policy_type => 'Registry Values',
             },
@@ -875,7 +875,7 @@ class SecurityPolicy
                 :policy_type => 'Registry Values',
             },
             'Network access: Restrict anonymous access to Named Pipes and Shares' => {
-                :name => 'MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters\RestrictNullSessaccess',
+                :name => 'MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters\RestrictNullSessAccess',
                 :reg_type => '4',
                 :policy_type => 'Registry Values',
             },

--- a/lib/puppet_x/lsp/security_policy.rb
+++ b/lib/puppet_x/lsp/security_policy.rb
@@ -879,6 +879,17 @@ class SecurityPolicy
                 :reg_type => '4',
                 :policy_type => 'Registry Values',
             },
+            'Network security: Do not store LAN Manager hash value on next password change' => {
+                :name           => 'MACHINE\System\CurrentControlSet\Control\Lsa\NoLMHash',
+                :reg_type       => '4',
+                :policy_type    => 'Registry Values',
+                :data_type      => :boolean,
+            },
+            'Network security: LAN Manager authentication level' => {
+                :name           => 'MACHINE\System\CurrentControlSet\Control\Lsa\LmCompatibilityLevel',
+                :reg_type       => '4',
+                :policy_type    => 'Registry Values',
+            },
             "MACHINE\\System\\CurrentControlSet\\Control\\Lsa\\MSV1_0\\NTLMMinServerSec" => {
                 :name => "MACHINE\\System\\CurrentControlSet\\Control\\Lsa\\MSV1_0\\NTLMMinServerSec",
                 :policy_type => "Registry Values",

--- a/spec/unit/puppet/type/local_security_policy/local_security_policy_spec.rb
+++ b/spec/unit/puppet/type/local_security_policy/local_security_policy_spec.rb
@@ -31,7 +31,7 @@ describe Puppet::Type.type(:local_security_policy) do
               :ensure         => 'present',
               :policy_setting => "AuditAccountLogon",
               :policy_type    => "Event Audit",
-              :policy_value   => 'xuccess,Failure',
+              :policy_value   => 'Success,Failure',
           )}.to raise_error(Puppet::ResourceError)
     end
   end


### PR DESCRIPTION
With this PR I have added two new policies. Some policies kept reapplying on every Puppet run because the key didn't match the case in the secedit output. Also two policies were managing the same key. Probably some copy/paste error.