### PR TITLE
add support for old-style loading

### DIFF
--- a/lib/puppet/provider/local_security_policy/policy.rb
+++ b/lib/puppet/provider/local_security_policy/policy.rb
@@ -7,8 +7,14 @@ begin
 rescue LoadError => detail
   require 'pathname' # JJM WORK_AROUND #14073
   mod = Puppet::Module.find('local_security_policy', Puppet[:environment].to_s)
-  require File.join(mod.path, 'lib/puppet_x/twp/inifile')
-  require File.join(mod.path, 'lib/puppet_x/lsp/security_policy')
+  if mod
+    require File.join(mod.path, 'lib/puppet_x/twp/inifile')
+    require File.join(mod.path, 'lib/puppet_x/lsp/security_policy')
+  else # received nil, fallback to old style
+    module_base = Pathname.new(__FILE__).dirname
+    require File.join(module_base, '../../../', 'puppet_x/twp/inifile')
+    require File.join(module_base, '../../../', 'puppet_x/lsp/security_policy')
+  end
 end
 
 Puppet::Type.type(:local_security_policy).provide(:policy) do

--- a/lib/puppet/type/local_security_policy.rb
+++ b/lib/puppet/type/local_security_policy.rb
@@ -4,7 +4,12 @@ begin
 rescue LoadError => detail
   require 'pathname' # JJM WORK_AROUND #14073
   mod = Puppet::Module.find('local_security_policy', Puppet[:environment].to_s)
-  require File.join(mod.path, 'lib/puppet_x/lsp/security_policy')
+  if mod
+    require File.join(mod.path, 'lib/puppet_x/lsp/security_policy')
+  else # received nil, fallback to old style
+    module_base = Pathname.new(__FILE__).dirname
+    require File.join(module_base, '../../', 'puppet_x/lsp/security_policy')
+  end
 end
 
 Puppet::Type.newtype(:local_security_policy) do


### PR DESCRIPTION
This fixes https://github.com/ayohrling/local_security_policy/issues/21 for me. I figure we can support the old way the files were loaded as a fallback. It shouldn't affect any existing setups that work.

The problem I was having was `Puppet::Module.find('local_security_policy', Puppet[:environment].to_s)` was returning `nil`. `Puppet[:environment].to_s` was always returning production for some reason. This was the case even when my test node was in the `qa` environment. This fallback will allow things to work gracefully.