### PR TITLE
'fixed case in No auditing [issue 25]'

### DIFF
--- a/lib/puppet_x/lsp/security_policy.rb
+++ b/lib/puppet_x/lsp/security_policy.rb
@@ -3,7 +3,7 @@ require 'puppet/provider'
 
 class SecurityPolicy
     attr_reader :wmic_cmd
-    EVENT_TYPES = ["Success,Failure", "Success", "Failure", "No Auditing", 0, 1, 2, 3]
+    EVENT_TYPES = ["Success,Failure", "Success", "Failure", "No auditing", 0, 1, 2, 3]
 
     def initialize
         # suppose to make an instance method for wmic


### PR DESCRIPTION
This fixes the case in the security_policy.rb file.  This was tested on Windows 2012 R2.