### PR TITLE
#29 Munging error on domain controllers

### DIFF
--- a/lib/puppet_x/lsp/security_policy.rb
+++ b/lib/puppet_x/lsp/security_policy.rb
@@ -20,6 +20,9 @@ class SecurityPolicy
                 # will not cache
                 wmic_cmd.execute(args).force_encoding('utf-16le').encode('utf-8', :universal_newline => true).gsub("\xEF\xBB\xBF", '')
         end
+    rescue
+        warn "local_security_policy: wmic: encoding failed"
+        wmic_cmd.execute(args)
     end
 
     # collect all the local accounts using wmic
@@ -27,8 +30,7 @@ class SecurityPolicy
         ary = []
         ["useraccount","group"].each do |lu|
             wmic([lu, 'where', "(domain=\"#{ENV["COMPUTERNAME"]}\")", 'get', 'name,sid', '/format:csv']).split("\n").each do |line|
-                next if line =~ /Node/
-                if line.include? ","
+                if line.include? "#{ENV["COMPUTERNAME"]},"
                     ary << line.strip.split(",")
                 end
             end


### PR DESCRIPTION
Resolves the following error on domain controllers.

> Error: Failed to apply catalog: Parameter policy_value failed on Local_security_
> policy[Create global objects]: Munging failed for value "Administrators" in clas
> s policy_value: incomplete "\x00" on UTF-16LE

Desired settings for well-known groups are applied on domain controllers after this change.  Settings are still applied on non domain controllers as well.

fixes #29