### PR TITLE
Drop "windows" tag

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -29,8 +29,9 @@
     }
   ],
   "tags": [
-    "windows",
-    "security"
+    "security",
+    "policy",
+    "secedit"
   ],
   "pdk-version": "1.18.0",
   "template-url": "pdk-default#1.18.0",


### PR DESCRIPTION
Puppet's module metadata guidelines prohibit the use of OS names in
tags.  This drops `windows` from the tags, but adds `policy` and
`secedit` to help with discoverability on the Forge.

Fixes #97.