### PR TITLE
SDDL values are not idempotent

### DIFF
--- a/lib/puppet_x/twp/inifile.rb
+++ b/lib/puppet_x/twp/inifile.rb
@@ -425,8 +425,7 @@ module PuppetX # rubocop:disable Style/ClassAndModuleChildren
         @hash = hash
         @default = default
 
-        comment = comment.to_s.empty? ? '\\z' : "\\s*(?:[#{comment}].*)?\\z"
-
+        comment = comment.to_s.empty? ? '\\z' : "\\s*(?:(?<=(?:\\A|\\s))[#{comment}].*)?\\z"
         @section_regexp  = %r{\A\s*\[([^\]]+)\]#{comment}}
         @ignore_regexp   = %r{\A#{comment}}
         @property_regexp = %r{\A(.*?)(?<!\\)#{param}(.*)\z}

--- a/spec/acceptance/suites/04_registry_values_spec.rb
+++ b/spec/acceptance/suites/04_registry_values_spec.rb
@@ -13,10 +13,9 @@ describe 'local_security_policy' do
   context 'enable registry value policy' do
     let(:manifest) do
       <<~END
-      local_security_policy {
-        'Network access: Restrict clients allowed to make remote calls to SAM':
-          ensure => present,
-          policy_value => '1,"O:BAG:BAD:(A;;RC;;;BA)"',
+      local_security_policy { 'Network access: Restrict clients allowed to make remote calls to SAM':
+        ensure => present,
+        policy_value => '1,"O:BAG:BAD:(A;;RC;;;BA)"',
       }
       END
     end
@@ -30,7 +29,7 @@ describe 'local_security_policy' do
     it 'sets the value correctly' do
       hosts.each do |host|
         value = get_reg_key_on(host, 'HKLM:\System\CurrentControlSet\Control\Lsa')
-        expect(value['RestrictRemoteSAM']).to eq('O:BAG:BAD:(A;;RC;;;BA)')
+        expect(value['restrictremotesam']).to eq('O:BAG:BAD:(A;;RC;;;BA)')
       end
     end
   end
@@ -38,10 +37,9 @@ describe 'local_security_policy' do
   context 'disable registry value policy' do
     let(:manifest) do
       <<~END
-      local_security_policy {
-        'Network access: Restrict clients allowed to make remote calls to SAM':
-          ensure => present,
-          policy_value => '',
+      local_security_policy { 'Network access: Restrict clients allowed to make remote calls to SAM':
+        ensure => present,
+        policy_value => '',
       }
       END
     end
@@ -55,7 +53,7 @@ describe 'local_security_policy' do
     it 'sets the value correctly' do
       hosts.each do |host|
         value = get_reg_key_on(host, 'HKLM:\System\CurrentControlSet\Control\Lsa')
-        expect(value['RestrictRemoteSAM']).to eq('')
+        expect(value['restrictremotesam']).to eq('')
       end
     end
   end

--- a/spec/acceptance/suites/04_registry_values_spec.rb
+++ b/spec/acceptance/suites/04_registry_values_spec.rb
@@ -13,10 +13,11 @@ describe 'local_security_policy' do
   context 'enable registry value policy' do
     let(:manifest) do
       <<~END
-        local_security_policy { 'System objects: Strengthen default permissions of internal system objects (e.g., Symbolic Links)':
-          ensure       => present,
-          policy_value => '4,1',
-        }
+      local_security_policy {
+        'Network access: Restrict clients allowed to make remote calls to SAM':
+          ensure => present,
+          policy_value => '1,"O:BAG:BAD:(A;;RC;;;BA)"',
+      }
       END
     end
 
@@ -28,9 +29,8 @@ describe 'local_security_policy' do
 
     it 'sets the value correctly' do
       hosts.each do |host|
-        # value = get_registry_value_on(host, :hklm, 'SYSTEM\CurrentControlSet\Control\Session Manager', 'ProtectionMode')
-        value = get_reg_key_on(host, 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager')
-        expect(value['ProtectionMode']).to eq(1)
+        value = get_reg_key_on(host, 'HKLM:\System\CurrentControlSet\Control\Lsa')
+        expect(value['RestrictRemoteSAM']).to eq("O:BAG:BAD:(A;;RC;;;BA)")
       end
     end
   end
@@ -38,10 +38,11 @@ describe 'local_security_policy' do
   context 'disable registry value policy' do
     let(:manifest) do
       <<~END
-        local_security_policy { 'System objects: Strengthen default permissions of internal system objects (e.g., Symbolic Links)':
-          ensure       => present,
-          policy_value => '4,0',
-        }
+      local_security_policy {
+        'Network access: Restrict clients allowed to make remote calls to SAM':
+          ensure => present,
+          policy_value => '',
+      }
       END
     end
 
@@ -53,9 +54,8 @@ describe 'local_security_policy' do
 
     it 'sets the value correctly' do
       hosts.each do |host|
-        # value = get_registry_value_on(host, :hklm, 'SYSTEM\CurrentControlSet\Control\Session Manager', 'ProtectionMode')
-        value = get_reg_key_on(host, 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager')
-        expect(value['ProtectionMode']).to eq(0)
+        value = get_reg_key_on(host, 'HKLM:\System\CurrentControlSet\Control\Lsa')
+        expect(value['RestrictRemoteSAM']).to eq('')
       end
     end
   end

--- a/spec/acceptance/suites/04_registry_values_spec.rb
+++ b/spec/acceptance/suites/04_registry_values_spec.rb
@@ -30,7 +30,7 @@ describe 'local_security_policy' do
     it 'sets the value correctly' do
       hosts.each do |host|
         value = get_reg_key_on(host, 'HKLM:\System\CurrentControlSet\Control\Lsa')
-        expect(value['RestrictRemoteSAM']).to eq("O:BAG:BAD:(A;;RC;;;BA)")
+        expect(value['RestrictRemoteSAM']).to eq('O:BAG:BAD:(A;;RC;;;BA)')
       end
     end
   end


### PR DESCRIPTION
Modifies regex used to detect comments, requiring a preceding space or beginning of line.

Fixes #108